### PR TITLE
set some function template parameters explicitly because Clang 3.2 canno...

### DIFF
--- a/test/object/ObjectStoreTestUnit.cpp
+++ b/test/object/ObjectStoreTestUnit.cpp
@@ -118,7 +118,8 @@ ObjectStoreTestUnit::expression_test()
 
   variable<int> k(make_var(&ObjectItem<Item>::ptr, &Item::get_int));
 
-  variable<int> z(make_var(&ObjectItemType::value, &ObjectItem<Item>::get_int));
+  //Clang 3.2 needs the explicit template parameters on make_var
+  variable<int> z(make_var<int, ObjectItemType, object_item_ptr>(&ObjectItemType::value, &ObjectItem<Item>::get_int));
 
   ObjectItemPtrList::const_iterator it = std::find_if(itemlist->begin(), itemlist->end(), z == 4);
   UNIT_ASSERT_FALSE(it == itemlist->end(), "couldn't find item");


### PR DESCRIPTION
...t infer them from the arguments.

The corresponding signature of make_var is:

template < class R, class O, class O1 >
variable<R>
make_var(O1 (O::*mem_func)() const, R (O1::object_type::*mem_func_1)() const);

I am not sure why GCC can deduce O1 but Clang cannot. My commit works for both Clang 3.2 and GCC 4.8.