### PR TITLE
Fixes the issue where the integration test passes regardless of unit test failures

### DIFF
--- a/lib/src/unit/test_suite.cpp
+++ b/lib/src/unit/test_suite.cpp
@@ -138,7 +138,7 @@ bool test_suite::run()
           return result;
         } else {
           unit_executer ue(summary_);
-          std::for_each(unit_test_map_.begin(), unit_test_map_.end(), ue);
+          std::for_each(unit_test_map_.begin(), unit_test_map_.end(), std::ref(ue));
           std::cout << summary_;
           return ue.succeeded;
         }

--- a/test/test_oos.cpp
+++ b/test/test_oos.cpp
@@ -56,6 +56,8 @@
 #endif
 #endif
 
+#include <cstdlib> // EXIT_SUCCESS
+
 using namespace oos;
 
 int main(int argc, char *argv[])
@@ -114,5 +116,5 @@ int main(int argc, char *argv[])
 //  suite.register_unit(new JsonTestUnit());
 
   bool result = suite.run();
-  return result ? 0 : 1;
+  return result ? EXIT_SUCCESS : EXIT_FAILURE;
 }


### PR DESCRIPTION
So was the (Travis/AppVeyor)CI were passing.
Recently I've found out that when some tests fail and reports `FAILED` in the status, the total summary of CI job still passes:

```
1: summary for 253 tests with 992 asserts: (succeeded: 174), (failures: 79), (errors: 0)
1/1 Test #1: test_oos_all .....................   Passed    3.01 sec
```

---

After some investigation I've figured out a bug in the test library code:
```cpp
unit_executer ue(summary_);
std::for_each(unit_test_map_.begin(), unit_test_map_.end(), ue);
```

This must be written in this way:
```cpp
unit_executer ue(summary_);
std::for_each(unit_test_map_.begin(), unit_test_map_.end(), std::ref(ue) /* <-- */);
```
-- because the function object is passed by value, not by reference.

This caused the entire test unit suite to be copied and hence the "`succeeded`" value had always been set to the default value, which is `true`.